### PR TITLE
[Security] Remove Client Secret from Frontend

### DIFF
--- a/src/main/java/com/vankyle/id/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/vankyle/id/config/AuthorizationServerConfig.java
@@ -111,9 +111,8 @@ public class AuthorizationServerConfig {
                 .clientIdIssuedAt(Instant.now())
                 .clientName("Vankyle ID")
                 .clientSecret("client_secret")
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .redirectUri("/oidc")
                 .scope(OidcScopes.OPENID)
                 .scope(OidcScopes.PROFILE)
@@ -123,9 +122,10 @@ public class AuthorizationServerConfig {
                 .scope("roles")
                 .clientSettings(
                         ClientSettings.builder()
-                                .requireAuthorizationConsent(true)
-                                .build())
-                .build();
+                                .requireProofKey(true)
+                                .requireAuthorizationConsent(false)
+                                .build()
+                ).build();
         if (registeredClientRepository.findByClientId("account") == null) {
             registeredClientRepository.save(account_frontend);
         } else {

--- a/web/src/auth/userManager.ts
+++ b/web/src/auth/userManager.ts
@@ -7,7 +7,6 @@ const userManagerSettings: UserManagerSettings = {
     authority: "/",
     redirect_uri: "/oidc",
     client_id: "account",
-    client_secret: "client_secret",
     scope: "openid profile email phone address roles",
     loadUserInfo: true
 };


### PR DESCRIPTION
The front-end client (under the `/web`) is now using client secret to allocate token from token endpoint. This PR changes the frontend using PKCE to authenticate the client, so the client doesn't need to store the client secret. This is a security update; every production use case should upgrade to this version immediately. 

This PR also included following update: 

- Fix the URL mismatch in admin page
- Adjust admin layout 
- Fix login failed message when backend returning 401 HTTP response